### PR TITLE
log.Fatal -> return error

### DIFF
--- a/epic.go
+++ b/epic.go
@@ -3,7 +3,6 @@ package fornitego
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -167,7 +166,7 @@ func (s *Session) QueryPlayer(name, platform string) (*Player, error) {
 func (s *Session) findUserInfo(username string) (*lookupResponse, error) {
 	req, err := s.client.NewRequest(http.MethodGet, accountLookupURL+"/lookup?q="+url.QueryEscape(username), nil)
 	if err != nil {
-		log.Fatalln(err)
+		return nil, err
 	}
 
 	// Set authorization to use access token.
@@ -176,7 +175,7 @@ func (s *Session) findUserInfo(username string) (*lookupResponse, error) {
 	ret := &lookupResponse{}
 	resp, err := s.client.Do(req, ret)
 	if err != nil {
-		log.Fatalln(err)
+		return nil, err
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
Hi, thank you for the library -- it has been very helpful so far in development.

I am sending in a small pull request that converts 2 `log.Fatalln` calls to simple error returns. Currently, if a user calls my service with an invalid username (a typo), my app will always crash and I'm not able to recover. I'd like to be able to handle the error myself.