### PR TITLE
This adds the ability for someone to query by account id as well as username

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ To retrieve a player's information and statistics for Battle Royale:
 sess := fornitego.Create("USERNAME", "PASSWORD", "LAUNCHER-TOKEN", "GAME-TOKEN")
 
 // Retrieve player info and stats by Username and Platform.
-player, err := s.QueryPlayer("PlayerName", fornitego.PC) // (PC/Xbox/PS4)
+player, err := s.QueryPlayer("PlayerName", fornitego.PC, "") // (PC/Xbox/PS4)
+if err != nil {
+	fmt.Println(err)
+}
+
+// Retrieve player info and stats by Account ID and Platform.
+player, err := s.QueryPlayer("", fornitego.PC, "AccountID") // (PC/Xbox/PS4)
 if err != nil {
 	fmt.Println(err)
 }

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ To retrieve a player's information and statistics for Battle Royale:
 sess := fornitego.Create("USERNAME", "PASSWORD", "LAUNCHER-TOKEN", "GAME-TOKEN")
 
 // Retrieve player info and stats by Username and Platform.
-player, err := s.QueryPlayer("PlayerName", fornitego.PC, "") // (PC/Xbox/PS4)
+player, err := s.QueryPlayer("PlayerName", "", fornitego.PC) // (PC/Xbox/PS4)
 if err != nil {
 	fmt.Println(err)
 }
 
 // Retrieve player info and stats by Account ID and Platform.
-player, err := s.QueryPlayer("", fornitego.PC, "AccountID") // (PC/Xbox/PS4)
+player, err := s.QueryPlayer("", "AccountID", fornitego.PC) // (PC/Xbox/PS4)
 if err != nil {
 	fmt.Println(err)
 }

--- a/epic.go
+++ b/epic.go
@@ -116,8 +116,8 @@ type leaderboardEntry struct {
 
 // QueryPlayer looks up a player by their username and platform, and returns information about that player, namely, the
 // statistics for the 3 different party modes.
-func (s *Session) QueryPlayer(name string, platform string, account_id string) (*Player, error) {
-	if name == "" && account_id == "" {
+func (s *Session) QueryPlayer(name string, accountId string, platform string) (*Player, error) {
+	if name == "" && accountId == "" {
 		return nil, errors.New("no player name or id provided")
 	}
 	switch platform {
@@ -126,7 +126,7 @@ func (s *Session) QueryPlayer(name string, platform string, account_id string) (
 		return nil, errors.New("invalid platform specified")
 	}
 
-	if name != "" && account_id == "" {
+	if name != "" && accountId == "" {
 		userInfo, err := s.findUserInfo(name)
 		if err != nil {
 			return nil, err
@@ -134,24 +134,20 @@ func (s *Session) QueryPlayer(name string, platform string, account_id string) (
 		account_id = userInfo.ID
 	}
 
-	sr, err := s.QueryPlayerById(account_id)
+	sr, err := s.QueryPlayerById(accountId)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(*sr) == 0 {
-		return nil, errors.New("no statistics found for player " + account_id)
-	}
-
-	acctInfoMap, err := s.getAccountNames([]string{account_id})
+	acctInfoMap, err := s.getAccountNames([]string{accountId})
 	if err != nil {
 		return nil, err
 	}
-	cleanAcctID := strings.Replace(account_id, "-", "", -1)
+	cleanAcctID := strings.Replace(accountId, "-", "", -1)
 
 	return &Player{
 		AccountInfo: AccountInfo{
-			AccountID: account_id,
+			AccountID: accountId,
 			Username:  acctInfoMap[cleanAcctID],
 			Platform:  platform,
 		},
@@ -159,8 +155,8 @@ func (s *Session) QueryPlayer(name string, platform string, account_id string) (
 	}, nil
 }
 
-func (s *Session) QueryPlayerById(account_id string) (*statsResponse, error) {
-	u := fmt.Sprintf("%v/%v/%v/%v/%v", accountStatsURL, account_id, "bulk", "window", "alltime")
+func (s *Session) QueryPlayerById(accountId string) (*statsResponse, error) {
+	u := fmt.Sprintf("%v/%v/%v/%v/%v", accountStatsURL, accountId, "bulk", "window", "alltime")
 	req, err := s.client.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err
@@ -177,7 +173,7 @@ func (s *Session) QueryPlayerById(account_id string) (*statsResponse, error) {
 	defer resp.Body.Close()
 
 	if len(*sr) == 0 {
-		return nil, errors.New("no statistics found for player " + account_id)
+		return nil, errors.New("no statistics found for player " + accountId)
 	}
 
 	return sr, nil

--- a/epic.go
+++ b/epic.go
@@ -131,7 +131,7 @@ func (s *Session) QueryPlayer(name string, accountId string, platform string) (*
 		if err != nil {
 			return nil, err
 		}
-		account_id = userInfo.ID
+		accountId = userInfo.ID
 	}
 
 	sr, err := s.QueryPlayerById(accountId)

--- a/epic.go
+++ b/epic.go
@@ -116,9 +116,9 @@ type leaderboardEntry struct {
 
 // QueryPlayer looks up a player by their username and platform, and returns information about that player, namely, the
 // statistics for the 3 different party modes.
-func (s *Session) QueryPlayer(name, platform string) (*Player, error) {
-	if name == "" {
-		return nil, errors.New("no player name provided")
+func (s *Session) QueryPlayer(name string, platform string, account_id string) (*Player, error) {
+	if name == "" && account_id == "" {
+		return nil, errors.New("no player name or id provided")
 	}
 	switch platform {
 	case PC, Xbox, PS4:
@@ -126,12 +126,41 @@ func (s *Session) QueryPlayer(name, platform string) (*Player, error) {
 		return nil, errors.New("invalid platform specified")
 	}
 
-	userInfo, err := s.findUserInfo(name)
+	if name != "" && account_id == "" {
+		userInfo, err := s.findUserInfo(name)
+		if err != nil {
+			return nil, err
+		}
+		account_id = userInfo.ID
+	}
+
+	sr, err := s.QueryPlayerById(account_id)
 	if err != nil {
 		return nil, err
 	}
 
-	u := fmt.Sprintf("%v/%v/%v/%v/%v", accountStatsURL, userInfo.ID, "bulk", "window", "alltime")
+	if len(*sr) == 0 {
+		return nil, errors.New("no statistics found for player " + account_id)
+	}
+
+	acctInfoMap, err := s.getAccountNames([]string{account_id})
+	if err != nil {
+		return nil, err
+	}
+	cleanAcctID := strings.Replace(account_id, "-", "", -1)
+
+	return &Player{
+		AccountInfo: AccountInfo{
+			AccountID: account_id,
+			Username:  acctInfoMap[cleanAcctID],
+			Platform:  platform,
+		},
+		Stats: s.mapStats(sr, platform),
+	}, nil
+}
+
+func (s *Session) QueryPlayerById(account_id string) (*statsResponse, error) {
+	u := fmt.Sprintf("%v/%v/%v/%v/%v", accountStatsURL, account_id, "bulk", "window", "alltime")
 	req, err := s.client.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err
@@ -148,18 +177,10 @@ func (s *Session) QueryPlayer(name, platform string) (*Player, error) {
 	defer resp.Body.Close()
 
 	if len(*sr) == 0 {
-		return nil, errors.New("no statistics found for player " + userInfo.DisplayName)
+		return nil, errors.New("no statistics found for player " + account_id)
 	}
 
-	return &Player{
-		AccountInfo: AccountInfo{
-			AccountID: userInfo.ID,
-			Username:  userInfo.DisplayName,
-			Platform:  platform,
-		},
-
-		Stats: s.mapStats(sr, platform),
-	}, nil
+	return sr, nil
 }
 
 // findUserInfo requests additional account information by a username.


### PR DESCRIPTION
Sometimes people change their Epic Username and it will cause issues. If you can record their account id and use that instead, then that is the better option